### PR TITLE
consuming Azure SDK for C lib as part of Zephyr app code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,5 +8,25 @@ project(hello_world)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake-modules")
 include(AddAzureSDKforC)
 
-target_sources(app PRIVATE src/main.c)
-target_link_libraries(app PRIVATE az_core)
+# Include Azure SDK for C headers to app
+target_include_directories(app PRIVATE ${azuresdkforc_SOURCE_DIR}/sdk/inc)
+
+# Let Zephyr build all 3rd party libs with app. Merge all into one
+target_sources(app PRIVATE
+    # Azure SDK for C - CORE lib
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_context.c
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_http_pipeline.c
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_http_policy.c
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_http_policy_logging.c
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_http_policy_retry.c
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_http_request.c
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_http_response.c
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_json_reader.c
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_json_token.c
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_json_writer.c
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_log.c
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_precondition.c
+    ${azuresdkforc_SOURCE_DIR}/sdk/src/azure/core/az_span.c
+    # Application sources
+    src/main.c)
+    

--- a/src/main.c
+++ b/src/main.c
@@ -7,21 +7,20 @@
 #include <zephyr.h>
 #include <sys/printk.h>
 
-#include <stdio.h>
-
 #include <azure/core/az_json.h>
 #include <azure/core/az_result.h>
 #include <azure/core/az_span.h>
 
 void main(void)
 {
-	printk("Hello World! %s\n", CONFIG_BOARD);
+	printk("Hello World!\n", CONFIG_BOARD);
 
 	az_span my_first_span = AZ_SPAN_FROM_STR("Hello Azure");
-	printk("%s\n", az_span_ptr(my_first_span));
+	// use size for printing az_span (since it is not 0 terminated.)
+	printk("%.*s\n", az_span_size(my_first_span), az_span_ptr(my_first_span));
 
-	uint8_t buffer[200] = { 0 };
-	az_json_writer writer = { 0 };
+	uint8_t buffer[200] = {0};
+	az_json_writer writer = {0};
 
 	az_result result = az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(buffer), NULL);
 	// {


### PR DESCRIPTION
Changes to sample application to enable Azure SDK for C library to be consumed and linked as part of customer application